### PR TITLE
Update array_first usage to match Laravel 5.3

### DIFF
--- a/src/Prettus/Repository/Generators/Migrations/RulesParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/RulesParser.php
@@ -81,7 +81,7 @@ class RulesParser implements Arrayable
      */
     public function getColumn($rules)
     {
-        return array_first(explode('=>', $rules), function ($key, $value) {
+        return array_first(explode('=>', $rules), function ($value, $key) {
             return $value;
         });
     }

--- a/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
@@ -113,7 +113,7 @@ class SchemaParser implements Arrayable
      */
     public function getColumn($schema)
     {
-        return array_first(explode(':', $schema), function ($key, $value) {
+        return array_first(explode(':', $schema), function ($value, $key) {
             return $value;
         });
     }


### PR DESCRIPTION
Laravel has switched the array_first helper arguments from  5.2 to 5.3.
Laravel 5.2 takes key, value and Laravel 5.3 takes value, key which then
messes up the Validator and Entity generators