### PR TITLE
 Fixed wrong generator

### DIFF
--- a/src/Prettus/Repository/Generators/Migrations/RulesParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/RulesParser.php
@@ -83,7 +83,7 @@ class RulesParser implements Arrayable
     public function getColumn($rules)
     {
         return array_first(explode('=>', $rules), function ($key, $value) {
-            return $value;
+            return $key;
         });
     }
 


### PR DESCRIPTION
When using php artisan make:entity Cat --fillable="title:string,content:text" --rules="title=>required|min:2, content=>sometimes|min:10"
files were generated wrong.